### PR TITLE
Remove to hash deprecation

### DIFF
--- a/lib/jimmy/log_entry.rb
+++ b/lib/jimmy/log_entry.rb
@@ -1,7 +1,7 @@
 module Jimmy
   class Entry < Hash
     def <<(hash)
-      self.merge!(hash)
+      self.merge!(hash.try(:to_unsafe_h) || hash)
     end
 
     def initialize(error_formatter: nil)


### PR DESCRIPTION
Treat ActionController::Parameters as plan hashes, and keep using plain hashes as such.

@andrewgristwood @dragosmiron @mineshdattani @sivanpatel