### PR TITLE
Cloudflare attrs

### DIFF
--- a/lib/jimmy/simple_request_logger.rb
+++ b/lib/jimmy/simple_request_logger.rb
@@ -83,8 +83,11 @@ module Jimmy
       # https://docs.aws.amazon.com/elasticloadbalancing/latest/application/load-balancer-request-tracing.html
       attributes.merge!(x_amzn_trace_id: env['HTTP_X_AMZN_TRACE_ID']) if env['HTTP_X_AMZN_TRACE_ID']
       
-      # Cloudflare adds the true client ip header to help differnatite from
-      # proxies. The trust score 
+      # Cloudflare adds the true client ip header to help differentiate from
+      # proxies. The trust score is provided as an indicator for malicous
+      # activity. While traffic can bypass Cloudflare I have added the
+      # x-forwarded-for header in so we can view and block clients that by pass
+      # the service.
       attributes.merge!(true_client_ip: env['HTTP_TRUE_CLIENT_IP']) if env['HTTP_TRUE_CLIENT_IP']
       attributes.merge!(cflare_trust_score: env['HTTP_CF_TRUST_SCORE']) if env['HTTP_CF_TRUST_SCORE']
       attributes.merge!(x_forwarded_for: env['HTTP_X_FORWARDED_FOR']) if env['HTTP_X_FORWARDED_FOR']

--- a/lib/jimmy/simple_request_logger.rb
+++ b/lib/jimmy/simple_request_logger.rb
@@ -82,12 +82,12 @@ module Jimmy
       # X-Amzn-Trace-Id is present for request incoming from Amazon ELB
       # https://docs.aws.amazon.com/elasticloadbalancing/latest/application/load-balancer-request-tracing.html
       attributes.merge!(x_amzn_trace_id: env['HTTP_X_AMZN_TRACE_ID']) if env['HTTP_X_AMZN_TRACE_ID']
-
+      
       # Cloudflare adds the true client ip header to help differnatite from
       # proxies. The trust score 
-      attributes.merge!(true_client_ip: env['TRUE_CLIENT_IP']) if env['TRUE_CLIENT_IP']
-      attributes.merge!(cflare_trust_score: env['CF_TRUST_SCORE']) if env['CF_TRUST_SCORE']
-      attributes.MERGE!(x_forwarded_for: env['X_FORWARDED_FOR']) if env['X_FORWARDED_FOR']
+      attributes.merge!(true_client_ip: env['HTTP_TRUE_CLIENT_IP']) if env['HTTP_TRUE_CLIENT_IP']
+      attributes.merge!(cflare_trust_score: env['HTTP_CF_TRUST_SCORE']) if env['HTTP_CF_TRUST_SCORE']
+      attributes.MERGE!(x_forwarded_for: env['HTTP_X_FORWARDED_FOR']) if env['HTTP_X_FORWARDED_FOR']
 
       attributes
     end

--- a/lib/jimmy/simple_request_logger.rb
+++ b/lib/jimmy/simple_request_logger.rb
@@ -83,6 +83,12 @@ module Jimmy
       # https://docs.aws.amazon.com/elasticloadbalancing/latest/application/load-balancer-request-tracing.html
       attributes.merge!(x_amzn_trace_id: env['HTTP_X_AMZN_TRACE_ID']) if env['HTTP_X_AMZN_TRACE_ID']
 
+      # Cloudflare adds the true client ip header to help differnatite from
+      # proxies. The trust score 
+      attributes.merge!(true_client_ip: env['TRUE_CLIENT_IP']) if env['TRUE_CLIENT_IP']
+      attributes.merge!(cflare_trust_score: env['CF_TRUST_SCORE']) if env['CF_TRUST_SCORE']
+      attributes.MERGE!(x_forwarded_for: env['X_FORWARDED_FOR']) if env['X_FORWARDED_FOR']
+
       attributes
     end
 

--- a/lib/jimmy/simple_request_logger.rb
+++ b/lib/jimmy/simple_request_logger.rb
@@ -87,7 +87,7 @@ module Jimmy
       # proxies. The trust score 
       attributes.merge!(true_client_ip: env['HTTP_TRUE_CLIENT_IP']) if env['HTTP_TRUE_CLIENT_IP']
       attributes.merge!(cflare_trust_score: env['HTTP_CF_TRUST_SCORE']) if env['HTTP_CF_TRUST_SCORE']
-      attributes.MERGE!(x_forwarded_for: env['HTTP_X_FORWARDED_FOR']) if env['HTTP_X_FORWARDED_FOR']
+      attributes.merge!(x_forwarded_for: env['HTTP_X_FORWARDED_FOR']) if env['HTTP_X_FORWARDED_FOR']
 
       attributes
     end

--- a/lib/jimmy/version.rb
+++ b/lib/jimmy/version.rb
@@ -1,3 +1,3 @@
 module Jimmy
-  VERSION = '0.4.1'
+  VERSION = '0.4.2'
 end


### PR DESCRIPTION
This change logs some additional HTTP headers which will be supplied by Cloudflare. 

Tested using dev and supplying the headers via a proxy:

```{"timestamp":"2019-02-15T22:39:27.339Z","duration":0.063533,"remote_address":"127.0.0.1","uri":"/assets/ci5/application-ed71ea390a8194eb02b3a8051fc0ab272ec667c88cdeb425d3aa71848c9c5b63.css","user_agent":"Mozilla/5.0
(Macintosh; Intel Mac OS X 10.14; rv:64.0) Gecko/20100101
Firefox/64.0","referer":"http://127.0.0.1:1337/q/business/new_business/about_your_business/5c673e4cdd1e5987db1f4ccf","query_params":{},"request_method":"GET","local_address":"192.168.20.100","client_address":"127.0.0.1","response_code":200}

{"controller":"journey","action":"new","session_id":null,"timestamp":"2019-02-15T22:39:46.391Z","duration":0.082876,"remote_address":"127.0.0.1","uri":"/","user_agent":null,"referer":null,"query_params":{},"request_method":"GET","true_client_ip":"1.1.1.1","cflare_trust_score":"22","x_forwarded_for":"9.9.9.9","local_address":"192.168.20.100","client_address":"9.9.9.9","response_code":302}```


