### PR TITLE
Add release section

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,13 +120,14 @@ Simple usage example:
 Jimmy::Ruby:Logger.instance.log({message: "Error message"})
 ```
 
-## Releasing
+## Contributing
 
-1. Create your feature branch (`git checkout -b my-new-feature`)
-2. Commit your changes (`git commit -am 'Added some feature'`)
-3. Push to the branch (`git push origin my-new-feature`)
-4. Edit `./lib/jimmy/version.rb` and bump the version
-5. Create new Pull Request
+1. Fork it
+2. Create your feature branch (`git checkout -b my-new-feature`)
+3. Commit your changes (`git commit -am 'Added some feature'`)
+4. Push to the branch (`git push origin my-new-feature`)
+5. Edit `./lib/jimmy/version.rb` and bump the version
+6. Create new Pull Request
 
 ## Copyright
 

--- a/README.md
+++ b/README.md
@@ -120,35 +120,13 @@ Simple usage example:
 Jimmy::Ruby:Logger.instance.log({message: "Error message"})
 ```
 
-## Contributing
+## Releasing
 
-1. Fork it
-2. Create your feature branch (`git checkout -b my-new-feature`)
-3. Commit your changes (`git commit -am 'Added some feature'`)
-4. Push to the branch (`git push origin my-new-feature`)
+1. Create your feature branch (`git checkout -b my-new-feature`)
+2. Commit your changes (`git commit -am 'Added some feature'`)
+3. Push to the branch (`git push origin my-new-feature`)
+4. Edit `./lib/jimmy/version.rb` and bump the version
 5. Create new Pull Request
-
-## For maintainers
-
-Use `gem-release` to maintain versions https://github.com/svenfuchs/gem-release.
-
-To update the patch version (e.g. 0.0.1 to 0.0.2), after merging the PR to `master` run:
-
-```
-gem bump --tag --release
-```
-
-if instead you want to bump the minor version (e.g. 0.0.1 to 0.1.0):
-
-```
-gem bump --version minor --tag --release
-```
-
-or major version (e.g. 0.0.1 to 1.0.0):
-
-```
-gem bump --version major --tag --release
-```
 
 ## Copyright
 

--- a/lib/jimmy/version.rb
+++ b/lib/jimmy/version.rb
@@ -1,3 +1,3 @@
 module Jimmy
-  VERSION = '0.4.4'
+  VERSION = '0.4.5'
 end


### PR DESCRIPTION
## What

The release section doesn't describe how to release Jimmy. This update makes it more clear.

## Why

Because if the Jimmy version isn't bumped properly CI fails.