### PR TITLE
[ATLAS-126] fix deprecation warning for use of jimmy in newer versions of rails

### DIFF
--- a/jimmy.gemspec
+++ b/jimmy.gemspec
@@ -19,6 +19,8 @@ Gem::Specification.new do |spec|
   spec.description   = ''
   spec.homepage      = 'https://github.com/simplybusiness/jimmy'
 
+  spec.required_ruby_version = ">= 2.5.0"
+
   spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   spec.bindir        = 'exe'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
@@ -26,7 +28,7 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'rake'
-
   spec.add_dependency 'rack', '>= 1.4'
   spec.add_dependency 'actionpack'
+  spec.add_dependency "activesupport",'6.0.0'
 end

--- a/jimmy.gemspec
+++ b/jimmy.gemspec
@@ -19,8 +19,6 @@ Gem::Specification.new do |spec|
   spec.description   = ''
   spec.homepage      = 'https://github.com/simplybusiness/jimmy'
 
-  spec.required_ruby_version = ">= 2.5.0"
-
   spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   spec.bindir        = 'exe'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
@@ -28,7 +26,7 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'rake'
+
   spec.add_dependency 'rack', '>= 1.4'
   spec.add_dependency 'actionpack'
-  spec.add_dependency "activesupport",'6.0.0'
 end

--- a/lib/jimmy/rails/request_logger.rb
+++ b/lib/jimmy/rails/request_logger.rb
@@ -38,7 +38,7 @@ module Jimmy
       end
 
       def filter_attributes(attributes)
-        @filter ||= ActionDispatch::Http::ParameterFilter.new(::Rails.application.config.filter_parameters)
+        @filter ||= ActiveSupport::ParameterFilter.new(::Rails.application.config.filter_parameters)
         key_filtererd_attributes = @filter.filter attributes
         return key_filtererd_attributes unless Jimmy.configuration.filter_uri
         filter_uri_query(key_filtererd_attributes)

--- a/lib/jimmy/rails/request_logger.rb
+++ b/lib/jimmy/rails/request_logger.rb
@@ -38,7 +38,9 @@ module Jimmy
       end
 
       def filter_attributes(attributes)
-        @filter ||= ActiveSupport::ParameterFilter.new(::Rails.application.config.filter_parameters)
+        klass = defined?(ActiveSupport::ParameterFilter) ?
+        ActiveSupport::ParameterFilter : ActionDispatch::Http::ParameterFilter
+        @filter ||= klass.new(::Rails.application.config.filter_parameters)
         key_filtererd_attributes = @filter.filter attributes
         return key_filtererd_attributes unless Jimmy.configuration.filter_uri
         filter_uri_query(key_filtererd_attributes)

--- a/lib/jimmy/rails/request_logger.rb
+++ b/lib/jimmy/rails/request_logger.rb
@@ -39,7 +39,7 @@ module Jimmy
 
       def filter_attributes(attributes)
         klass = defined?(ActiveSupport::ParameterFilter) ?
-        ActiveSupport::ParameterFilter : ActionDispatch::Http::ParameterFilter
+          ActiveSupport::ParameterFilter : ActionDispatch::Http::ParameterFilter
         @filter ||= klass.new(::Rails.application.config.filter_parameters)
         key_filtererd_attributes = @filter.filter attributes
         return key_filtererd_attributes unless Jimmy.configuration.filter_uri

--- a/lib/jimmy/version.rb
+++ b/lib/jimmy/version.rb
@@ -1,3 +1,3 @@
 module Jimmy
-  VERSION = '0.4.6'
+  VERSION = '0.4.7'
 end

--- a/spec/rails/request_logger_spec.rb
+++ b/spec/rails/request_logger_spec.rb
@@ -1,4 +1,3 @@
-RAILS_VERSION_MAJOR = 6
 require 'spec_helper'
 require 'socket'
 require 'action_dispatch'

--- a/spec/rails/request_logger_spec.rb
+++ b/spec/rails/request_logger_spec.rb
@@ -2,7 +2,7 @@ RAILS_MAJOR_VERSION = 6
 require 'spec_helper'
 require 'socket'
 require 'action_dispatch'
-require 'active_support/parameter_filter' if ActiveSupport.version.to_s.to_i >= RAILS_MAJOR_VERSION
+require 'active_support/parameter_filter' if ActiveSupport::VERSION::MAJOR >= RAILS_MAJOR_VERSION
 
 describe Jimmy::Rails::RequestLogger do
   let(:app) { double(:app) }

--- a/spec/rails/request_logger_spec.rb
+++ b/spec/rails/request_logger_spec.rb
@@ -2,7 +2,7 @@ RAILS_VERSION_MAJOR = 6
 require 'spec_helper'
 require 'socket'
 require 'action_dispatch'
-require 'active_support/parameter_filter' if ActiveSupport::VERSION::MAJOR >= RAILS_VERSION_MAJOR
+require 'active_support/parameter_filter' if ActiveSupport::VERSION::MAJOR >= 6
 
 describe Jimmy::Rails::RequestLogger do
   let(:app) { double(:app) }

--- a/spec/rails/request_logger_spec.rb
+++ b/spec/rails/request_logger_spec.rb
@@ -1,6 +1,7 @@
 require 'spec_helper'
 require 'socket'
 require 'action_dispatch'
+require "active_support/parameter_filter"
 
 describe Jimmy::Rails::RequestLogger do
   let(:app) { double(:app) }
@@ -76,14 +77,14 @@ describe Jimmy::Rails::RequestLogger do
     before do
       allow(::Rails).to receive_message_chain(:application, :config, :filter_parameters)
         .and_return filter_string
-      allow(ActionDispatch::Http::ParameterFilter).to receive(:new)
+      allow(ActiveSupport::ParameterFilter).to receive(:new)
         .and_return parameter_filter
       allow(parameter_filter).to receive(:filter).and_return(attributes)
     end
 
     context "without filter_uri configuration" do
       it 'instantiates a new ParameterFilter' do
-        expect(ActionDispatch::Http::ParameterFilter).to receive(:new).with(filter_string)
+        expect(ActiveSupport::ParameterFilter).to receive(:new).with(filter_string)
         subject.filter_attributes(attributes)
       end
 
@@ -101,7 +102,7 @@ describe Jimmy::Rails::RequestLogger do
       end
 
       it 'processes the parameter_filter filter as standard' do
-        expect(ActionDispatch::Http::ParameterFilter).to receive(:new).with(filter_string)
+        expect(ActiveSupport::ParameterFilter).to receive(:new).with(filter_string)
         expect(parameter_filter).to receive(:filter).with(attributes)
         subject.filter_attributes(attributes)
       end

--- a/spec/rails/request_logger_spec.rb
+++ b/spec/rails/request_logger_spec.rb
@@ -1,8 +1,8 @@
-RAILS_MAJOR_VERSION = 6
+RAILS_VERSION_MAJOR = 6
 require 'spec_helper'
 require 'socket'
 require 'action_dispatch'
-require 'active_support/parameter_filter' if ActiveSupport::VERSION::MAJOR >= RAILS_MAJOR_VERSION
+require 'active_support/parameter_filter' if ActiveSupport::VERSION::MAJOR >= RAILS_VERSION_MAJOR
 
 describe Jimmy::Rails::RequestLogger do
   let(:app) { double(:app) }

--- a/spec/rails/request_logger_spec.rb
+++ b/spec/rails/request_logger_spec.rb
@@ -1,7 +1,8 @@
+RAILS_MAJOR_VERSION = 6
 require 'spec_helper'
 require 'socket'
 require 'action_dispatch'
-require "active_support/parameter_filter"
+require 'active_support/parameter_filter' if ActiveSupport.version.to_s.to_i >= RAILS_MAJOR_VERSION
 
 describe Jimmy::Rails::RequestLogger do
   let(:app) { double(:app) }
@@ -62,9 +63,15 @@ describe Jimmy::Rails::RequestLogger do
   end
 
   describe '#filter_attributes' do
-
     subject { described_class.new(app) }
 
+    let(:klass) do
+      if defined?(ActiveSupport::ParameterFilter)
+        ActiveSupport::ParameterFilter
+      else
+        ActionDispatch::Http::ParameterFilter
+      end
+    end
     let(:filter_string) { [:personally_identifiable_info] }
     let(:parameter_filter) { double(:ParameterFilter) }
     let(:attributes) {
@@ -77,14 +84,14 @@ describe Jimmy::Rails::RequestLogger do
     before do
       allow(::Rails).to receive_message_chain(:application, :config, :filter_parameters)
         .and_return filter_string
-      allow(ActiveSupport::ParameterFilter).to receive(:new)
+      allow(klass).to receive(:new)
         .and_return parameter_filter
       allow(parameter_filter).to receive(:filter).and_return(attributes)
     end
 
     context "without filter_uri configuration" do
       it 'instantiates a new ParameterFilter' do
-        expect(ActiveSupport::ParameterFilter).to receive(:new).with(filter_string)
+        expect(klass).to receive(:new).with(filter_string)
         subject.filter_attributes(attributes)
       end
 
@@ -102,7 +109,7 @@ describe Jimmy::Rails::RequestLogger do
       end
 
       it 'processes the parameter_filter filter as standard' do
-        expect(ActiveSupport::ParameterFilter).to receive(:new).with(filter_string)
+        expect(klass).to receive(:new).with(filter_string)
         expect(parameter_filter).to receive(:filter).with(attributes)
         subject.filter_attributes(attributes)
       end


### PR DESCRIPTION
Ticket: https://trello.com/c/P0X7czeV/126-logging-for-model-viewer

### What 
Uses ActiveSupport::ParameterFilter over ActionDispatch::Http::ParameterFilter  : deprecation warning raised in rails6.1 

```
DEPRECATION WARNING: ActionDispatch::Http::ParameterFilter is deprecated and will be removed from Rails 6.1. Use ActiveSupport::ParameterFilter instead
```

### Why

 - using jimmy logging middlerware in rails6.1 application raises the above warning in the logs .

[x] @simplybusiness/atlas