### PR TITLE
upgrade versioning logic for dependabot

### DIFF
--- a/jimmy.gemspec
+++ b/jimmy.gemspec
@@ -3,15 +3,9 @@ lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'jimmy/version'
 
-gem_version = if ENV['GEM_PRE_RELEASE'].nil? || ENV['GEM_PRE_RELEASE'].empty?
-                Jimmy::VERSION
-              else
-                "#{Jimmy::VERSION}.#{ENV['GEM_PRE_RELEASE']}"
-              end
-
 Gem::Specification.new do |spec|
   spec.name          = 'jimmy'
-  spec.version       = gem_version
+  spec.version       = Jimmy::VERSION
   spec.authors       = ['Simply Business']
   spec.email         = ['tech@simplybusiness.co.uk']
 

--- a/lib/jimmy/version.rb
+++ b/lib/jimmy/version.rb
@@ -1,3 +1,7 @@
 module Jimmy
-  VERSION = '0.4.8'
+  VERSION = '0.4.8' # rubocop:disable Style/MutableConstant
+
+  # SB-specific versioning "algorithm" to accommodate BNW/Jenkins/gemstash
+  VERSION << '.' << ENV['GEM_PRE_RELEASE'].strip \
+  unless ENV.fetch('GEM_PRE_RELEASE', '').strip.empty?
 end


### PR DESCRIPTION
upgrade gemstash versioning logic so that dependabot can automatically
manage versions of dependencies in the gemspec

dependabot is used to create automatic PRs for security vulnerabilities