### PR TITLE
upgrade versioning logic for dependabot

### DIFF
--- a/jimmy.gemspec
+++ b/jimmy.gemspec
@@ -3,15 +3,9 @@ lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'jimmy/version'
 
-gem_version = if ENV['GEM_PRE_RELEASE'].nil? || ENV['GEM_PRE_RELEASE'].empty?
-                Jimmy::VERSION
-              else
-                "#{Jimmy::VERSION}.#{ENV['GEM_PRE_RELEASE']}"
-              end
-
 Gem::Specification.new do |spec|
   spec.name          = 'jimmy'
-  spec.version       = gem_version
+  spec.version       = Jimmy::VERSION
   spec.authors       = ['Simply Business']
   spec.email         = ['tech@simplybusiness.co.uk']
 

--- a/lib/jimmy/version.rb
+++ b/lib/jimmy/version.rb
@@ -1,5 +1,5 @@
 module Jimmy
-  base = '0.4.8'
+  base = '0.4.9'
 
   # SB-specific versioning "algorithm" to accommodate BNW/Jenkins/gemstash
   VERSION = (pre = ENV.fetch('GEM_PRE_RELEASE', '')).empty? ? base : "#{base}.#{pre}"

--- a/lib/jimmy/version.rb
+++ b/lib/jimmy/version.rb
@@ -1,3 +1,6 @@
 module Jimmy
-  VERSION = '0.4.8'
+  base = '0.4.8'
+
+  # SB-specific versioning "algorithm" to accommodate BNW/Jenkins/gemstash
+  VERSION = (pre = ENV.fetch('GEM_PRE_RELEASE', '')).empty? ? base : "#{base}.#{pre}"
 end


### PR DESCRIPTION
upgrade gemstash versioning logic so that dependabot can automatically
manage versions of dependencies in the gemspec

dependabot is used to create automatic PRs for security vulnerabilities