### PR TITLE
allow filter_uri to handle contained regexps

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Jimmy will filter any `Rails.application.config.filter_parameters` from the URI 
 
 **Important note**
 
-`Rails.application.config.filter_parameters` accepts symbols and regexps. For filtering uris, Jimmy will currently match only regexps that are complete strings (ie begin with `^` and end with `$`) and symbols.
+`Rails.application.config.filter_parameters` accepts symbols and regexps. For filtering uris, Jimmy will currently match only regexps that are complete strings (ie begin with `^` and end with `$`) and symbols, but it will treat them as fuzzy-finds - if you have a regexp filter for `^email$` it will also filter out `?email_address`. This is in line with how the symbol filters are currently applied.
 
 #### `logger_stream`
 

--- a/README.md
+++ b/README.md
@@ -81,6 +81,10 @@ Various configuration options are provided when setting up Jimmy in your Rails a
 Defaults to `false`. Can be configured in your Rails application's Jimmy initializer with `config.filter_uri = true`. If set to true,
 Jimmy will filter any `Rails.application.config.filter_parameters` from the URI query string as well as the query params.
 
+**Important note**
+
+`Rails.application.config.filter_parameters` accepts symbols and regexps. For filtering uris, Jimmy will currently match only regexps that are complete strings (ie begin with `^` and end with `$`) and symbols.
+
 #### `logger_stream`
 
 Can be used to specify the stream used for the logging output in your Jimmy initializer eg. `config.logger_stream = STDOUT`. Will default

--- a/lib/jimmy/rails/request_logger.rb
+++ b/lib/jimmy/rails/request_logger.rb
@@ -50,9 +50,17 @@ module Jimmy
 
       def filter_uri_query(attributes)
         ::Rails.application.config.filter_parameters.each do |matcher|
+          matcher = matcher.source[1...-1] if matcher_is_a_contained_regex?(matcher)
+
           attributes[:uri].gsub!(Regexp.new(matcher.to_s + '[^&]+'), "#{matcher}=[FILTERED]")
         end
         attributes
+      end
+
+      def matcher_is_a_contained_regex?(matcher)
+        return false unless matcher.is_a? Regexp
+
+        (/^\^.*\$$/).match? matcher.source
       end
 
       # See: http://coderrr.wordpress.com/2008/05/28/get-your-local-ip-address/

--- a/lib/jimmy/version.rb
+++ b/lib/jimmy/version.rb
@@ -1,5 +1,5 @@
 module Jimmy
-  base = '0.4.9'
+  base = '0.4.10'
 
   # SB-specific versioning "algorithm" to accommodate BNW/Jenkins/gemstash
   VERSION = (pre = ENV.fetch('GEM_PRE_RELEASE', '')).empty? ? base : "#{base}.#{pre}"

--- a/spec/rails/request_logger_spec.rb
+++ b/spec/rails/request_logger_spec.rb
@@ -113,9 +113,21 @@ describe Jimmy::Rails::RequestLogger do
         subject.filter_attributes(attributes)
       end
 
-      it 'additionally filters the the uri' do
-        filtered_attribues = subject.filter_attributes(attributes)
-        expect(filtered_attribues[:uri]).to eq "/example?personally_identifiable_info=[FILTERED]"
+      context 'with filter_parameters as symbols' do
+        it 'additionally filters the uri' do
+          filtered_attribues = subject.filter_attributes(attributes)
+          expect(filtered_attribues[:uri]).to eq "/example?personally_identifiable_info=[FILTERED]"
+        end
+      end
+
+      context 'with filter_parameters as contained regexps' do
+        let(:filter_string) { [/^word$/] }
+        let(:attributes) { { uri: "/example?word=solidity" } }
+
+        it 'additionally filters the uri' do
+          filtered_attribues = subject.filter_attributes(attributes)
+          expect(filtered_attribues[:uri]).to eq "/example?word=[FILTERED]"
+        end
       end
     end
   end


### PR DESCRIPTION
Rails `filter_parameters` allow regexps as well as symbols. We have only previously been using symbols, but we are now intending to add more specific regexps to avoid filtering parameters whose names happen to include params we _do_ want to filter.
Real world example - `email` is normally a thing we want to filter. `email_marketing_consent` is _not_ a thing we want to filter, but it gets caught in the crossfire if we don't use regexps.

`filter_uri` therefore needs to be updated to deal with regexps

note - this _only_ handles regexps that match full strings (ie begin with `^` and end with `$`), partially because of urgency