### PR TITLE
Make filter uri less brittle

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,10 +81,6 @@ Various configuration options are provided when setting up Jimmy in your Rails a
 Defaults to `false`. Can be configured in your Rails application's Jimmy initializer with `config.filter_uri = true`. If set to true,
 Jimmy will filter any `Rails.application.config.filter_parameters` from the URI query string as well as the query params.
 
-**Important note**
-
-`Rails.application.config.filter_parameters` accepts symbols and regexps. For filtering uris, Jimmy will currently match only regexps that are complete strings (ie begin with `^` and end with `$`) and symbols, but it will treat them as fuzzy-finds - if you have a regexp filter for `^email$` it will also filter out `?email_address`. This is in line with how the symbol filters are currently applied.
-
 #### `logger_stream`
 
 Can be used to specify the stream used for the logging output in your Jimmy initializer eg. `config.logger_stream = STDOUT`. Will default

--- a/lib/jimmy/rails/request_logger.rb
+++ b/lib/jimmy/rails/request_logger.rb
@@ -60,7 +60,7 @@ module Jimmy
         uri = URI.parse(attributes[:uri])
         return attributes unless uri.query
 
-        query_params = CGI.parse(uri.query)
+        query_params = Rack::Utils.parse_nested_query(uri.query)
         filtered_query_params = parameter_filter.filter(query_params)
 
         attributes[:uri] = build_filtered_request_uri(uri, filtered_query_params)

--- a/lib/jimmy/rails/request_logger.rb
+++ b/lib/jimmy/rails/request_logger.rb
@@ -50,6 +50,8 @@ module Jimmy
 
       def filter_uri_query(attributes)
         uri = URI.parse(attributes[:uri])
+        return attributes unless uri.query
+
         query_params = CGI.parse(uri.query)
         filtered_query_params = @filter.filter query_params
         attributes[:uri] = build_filtered_request_uri(uri, filtered_query_params)

--- a/lib/jimmy/rails/request_logger.rb
+++ b/lib/jimmy/rails/request_logger.rb
@@ -66,12 +66,6 @@ module Jimmy
         ).request_uri
       end
 
-      def matcher_is_a_contained_regex?(matcher)
-        return false unless matcher.is_a? Regexp
-
-        (/^\^.*\$$/).match? matcher.source
-      end
-
       # See: http://coderrr.wordpress.com/2008/05/28/get-your-local-ip-address/
       def determine_local_ip
         orig, Socket.do_not_reverse_lookup = Socket.do_not_reverse_lookup, true  # turn off reverse DNS resolution temporarily

--- a/lib/jimmy/rails/request_logger.rb
+++ b/lib/jimmy/rails/request_logger.rb
@@ -62,16 +62,15 @@ module Jimmy
 
         query_params = CGI.parse(uri.query)
         filtered_query_params = parameter_filter.filter(query_params)
+
         attributes[:uri] = build_filtered_request_uri(uri, filtered_query_params)
 
         attributes
       end
 
       def build_filtered_request_uri(uri, query_params)
-        URI::HTTP.build(
-          path: uri.path,
-          query: CGI.unescape(URI.encode_www_form(query_params))
-        ).request_uri
+        uri.query = CGI.unescape(URI.encode_www_form(query_params))
+        uri.to_s
       end
 
       # See: http://coderrr.wordpress.com/2008/05/28/get-your-local-ip-address/

--- a/lib/jimmy/version.rb
+++ b/lib/jimmy/version.rb
@@ -1,5 +1,5 @@
 module Jimmy
-  base = '0.4.10'
+  base = '0.4.11'
 
   # SB-specific versioning "algorithm" to accommodate BNW/Jenkins/gemstash
   VERSION = (pre = ENV.fetch('GEM_PRE_RELEASE', '')).empty? ? base : "#{base}.#{pre}"

--- a/spec/rails/request_logger_spec.rb
+++ b/spec/rails/request_logger_spec.rb
@@ -110,6 +110,17 @@ describe Jimmy::Rails::RequestLogger do
         expect(filtered_uri(attributes)).to eq "example?word=floof"
       end
 
+      it 'can handle the uri when it has incomplete params' do
+        attributes = [
+          { uri: "/example?word" },
+          { uri: "/example?word=" }
+        ]
+
+        attributes.each do |attrs|
+          expect(filtered_uri(attrs)).to eq attrs[:uri]
+        end
+      end
+
       context 'with filter_parameters as symbols' do
         it 'filters the uri for entire matches of the word' do
           expect(filtered_uri(attributes)).to eq "/example?personally_identifiable_info=[FILTERED]"

--- a/spec/rails/request_logger_spec.rb
+++ b/spec/rails/request_logger_spec.rb
@@ -64,13 +64,6 @@ describe Jimmy::Rails::RequestLogger do
   describe '#filter_attributes' do
     subject { described_class.new(app) }
 
-    let(:klass) do
-      if defined?(ActiveSupport::ParameterFilter)
-        ActiveSupport::ParameterFilter
-      else
-        ActionDispatch::Http::ParameterFilter
-      end
-    end
     let(:filter_string) { [:personally_identifiable_info] }
     let(:attributes) {
       {
@@ -85,11 +78,6 @@ describe Jimmy::Rails::RequestLogger do
     end
 
     context "without filter_uri configuration" do
-      it 'instantiates a new ParameterFilter' do
-        expect(klass).to receive(:new).with(filter_string).and_call_original
-        subject.filter_attributes(attributes)
-      end
-
       it 'filters the attributes' do
         filtered_attributes = subject.filter_attributes(attributes)
 

--- a/spec/rails/request_logger_spec.rb
+++ b/spec/rails/request_logger_spec.rb
@@ -70,12 +70,9 @@ describe Jimmy::Rails::RequestLogger do
     }
 
     context "without filter_uri configuration" do
-      before do
+      it 'filters the attributes' do
         filter_params = [:personally_identifiable_info]
         setup_rails_filter_params(filter_params)
-      end
-
-      it 'filters the attributes' do
         filtered_attributes = filter_attributes(attributes)
 
         expect(filtered_attributes[:query_params]).
@@ -143,12 +140,10 @@ describe Jimmy::Rails::RequestLogger do
       end
 
       context 'with filter_parameters as non-contained regexps' do
-        before do
+        it 'filters the uri for matches' do
           filter_params = [/l.*g/]
           setup_rails_filter_params(filter_params)
-        end
 
-        it 'filters the uri for matches' do
           attributes = { uri: "/example?longoword=solidity" }
           expect(filtered_uri(attributes)).to eq "/example?longoword=[FILTERED]"
         end

--- a/spec/rails/request_logger_spec.rb
+++ b/spec/rails/request_logger_spec.rb
@@ -103,6 +103,13 @@ describe Jimmy::Rails::RequestLogger do
         expect(filtered_uri(attributes)).to eq "/example"
       end
 
+      # we get these when we use url prefixes
+      it 'can handle uris without an absolute path' do
+        attributes = { uri: "example?word=floof" }
+
+        expect(filtered_uri(attributes)).to eq "example?word=floof"
+      end
+
       context 'with filter_parameters as symbols' do
         it 'filters the uri for entire matches of the word' do
           expect(filtered_uri(attributes)).to eq "/example?personally_identifiable_info=[FILTERED]"

--- a/spec/rails/request_logger_spec.rb
+++ b/spec/rails/request_logger_spec.rb
@@ -90,11 +90,11 @@ describe Jimmy::Rails::RequestLogger do
         subject.filter_attributes(attributes)
       end
 
-      it 'passes the attributes to the parameter_filter filter method' do
-        parameter_filter = double(:ParameterFilter)
-        allow(klass).to receive(:new).and_return parameter_filter
-        expect(parameter_filter).to receive(:filter).with(attributes)
-        subject.filter_attributes(attributes)
+      it 'filters the attributes' do
+        filtered_attributes = subject.filter_attributes(attributes)
+
+        expect(filtered_attributes[:query_params]).
+          to eq({ personally_identifiable_info: "[FILTERED]" })
       end
     end
 
@@ -105,7 +105,7 @@ describe Jimmy::Rails::RequestLogger do
         end
       end
 
-      it 'filters the attributes as standard' do
+      it 'filters the attributes' do
         filtered_attributes = subject.filter_attributes(attributes)
 
         expect(filtered_attributes[:query_params]).

--- a/spec/rails/request_logger_spec.rb
+++ b/spec/rails/request_logger_spec.rb
@@ -100,6 +100,13 @@ describe Jimmy::Rails::RequestLogger do
           to eq({ personally_identifiable_info: "[FILTERED]" })
       end
 
+      it 'returns the given uri when there are no query parameters' do
+        attributes = { uri: "/example" }
+
+        filtered_attributes = subject.filter_attributes(attributes)
+        expect(filtered_attributes[:uri]).to eq "/example"
+      end
+
       context 'with filter_parameters as symbols' do
         it 'filters the uri for entire matches of the word' do
           filtered_attributes = subject.filter_attributes(attributes)

--- a/spec/rails/request_logger_spec.rb
+++ b/spec/rails/request_logger_spec.rb
@@ -70,13 +70,15 @@ describe Jimmy::Rails::RequestLogger do
     }
 
     context "without filter_uri configuration" do
-      it 'filters the attributes' do
+      it 'filters the attributes except uri' do
         filter_params = [:personally_identifiable_info]
         setup_rails_filter_params(filter_params)
         filtered_attributes = filter_attributes(attributes)
 
-        expect(filtered_attributes[:query_params]).
-          to eq({ personally_identifiable_info: "[FILTERED]" })
+        expect(filtered_attributes).to eq({
+          uri: "/example?personally_identifiable_info=private_email@example.com",
+          query_params: { personally_identifiable_info: "[FILTERED]" }
+        })
       end
     end
 
@@ -90,7 +92,7 @@ describe Jimmy::Rails::RequestLogger do
         setup_rails_filter_params(filter_params)
       end
 
-      it 'filters the attributes' do
+      it 'filters the non-uri attributes' do
         filtered_attributes = filter_attributes(attributes)
 
         expect(filtered_attributes[:query_params]).


### PR DESCRIPTION
# What
This makes `filter_uri` behave the same way as Rails' `filter_parameters` by parsing the uri string back into a format that can be used with `ParameterFilter`.

# Why
As Jimmy's `filter_uri` depends on Rails' `filter_parameters`, it behaving in a different way is confusing and could potentially see us under or over filtering without noticing.