### PR TITLE
Remove syswrite

### DIFF
--- a/lib/jimmy/version.rb
+++ b/lib/jimmy/version.rb
@@ -1,5 +1,5 @@
 module Jimmy
-  base = '0.4.11'
+  base = '0.4.12'
 
   # SB-specific versioning "algorithm" to accommodate BNW/Jenkins/gemstash
   VERSION = (pre = ENV.fetch('GEM_PRE_RELEASE', '')).empty? ? base : "#{base}.#{pre}"

--- a/lib/jimmy/writer.rb
+++ b/lib/jimmy/writer.rb
@@ -20,11 +20,7 @@ module Jimmy
     attr_reader :stream
 
     def try_write(entry)
-      if stream.respond_to?(:syswrite)
-        stream.syswrite(entry)
-      else
         stream.write(entry)
-      end
     end
 
     def log_line_from(entry)

--- a/lib/jimmy/writer.rb
+++ b/lib/jimmy/writer.rb
@@ -20,7 +20,7 @@ module Jimmy
     attr_reader :stream
 
     def try_write(entry)
-        stream.write(entry)
+      stream.write(entry)
     end
 
     def log_line_from(entry)


### PR DESCRIPTION
With docker we can't use unbuffered IO, so we are spamming the logs due to this call.

from Mikio
```
/usr/lib64/ruby/gems/2.6.0/gems/jimmy-0.4.11/lib/jimmy/writer.rb:24: warning: syswrite for buffered IO
It’s saying “you asked for unbuffered IO, but FYI you’re not getting it.”
```
@simplybusiness/it-crowd @simplybusiness/silversmiths 
